### PR TITLE
should not install cap version above 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source "http://rubygems.org"
 # Include everything needed to run rake, tests, features, etc.
 group :development do
   gem "railsless-deploy", ">= 1.0.2"
-  gem "capistrano", ">= 2.12.0"
+  gem "capistrano", "~> 2.0"
   gem "shoulda", ">= 0"
   gem "bundler", "~> 1.1.3"
   gem "jeweler", "~> 1.6.4"


### PR DESCRIPTION
When installed didi will fail on cap version 3.x

```
/Users/robbiebardijn/.rvm/rubies/ruby-2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:126:in `require': cannot load such file -- capistrano/cli (LoadError)
    from /Users/robbiebardijn/.rvm/rubies/ruby-2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:126:in `require'
    from /Users/robbiebardijn/.rvm/gems/ruby-2.1.0/gems/capistrano-didi-0.4.4/bin/didi:3:in `<top (required)>'
    from /Users/robbiebardijn/.rvm/gems/ruby-2.1.0/bin/didi:23:in `load'
    from /Users/robbiebardijn/.rvm/gems/ruby-2.1.0/bin/didi:23:in `<main>'
    from /Users/robbiebardijn/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
    from /Users/robbiebardijn/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `<main>'
```
